### PR TITLE
Connection leak fix

### DIFF
--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -97,6 +97,7 @@ func (p *TCPProxy) Proxy(w io.Writer, r io.ReadCloser, msg *proto.ControlMessage
 		)
 		return
 	}
+	defer local.Close()
 
 	done := make(chan struct{})
 	go func() {

--- a/utils.go
+++ b/utils.go
@@ -7,36 +7,21 @@ package tunnel
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/mmatczuk/go-http-tunnel/log"
 )
 
-type closeWriter interface {
-	CloseWrite() error
-}
-
-type closeReader interface {
-	CloseRead() error
-}
-
 func transfer(dst io.Writer, src io.ReadCloser, logger log.Logger) {
 	n, err := io.Copy(dst, src)
 	if err != nil {
-		logger.Log(
-			"level", 2,
-			"msg", "copy error",
-			"err", err,
-		)
-	}
-
-	if d, ok := dst.(closeWriter); ok {
-		d.CloseWrite()
-	}
-
-	if s, ok := src.(closeReader); ok {
-		s.CloseRead()
-	} else {
-		src.Close()
+		if !strings.Contains(err.Error(), "context canceled") && !strings.Contains(err.Error(), "CANCEL") {
+			logger.Log(
+				"level", 2,
+				"msg", "copy error",
+				"err", err,
+			)
+		}
 	}
 
 	logger.Log(

--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mmatczuk/go-http-tunnel/log"
 )
 
-func transfer(dst io.Writer, src io.ReadCloser, logger log.Logger) {
+func transfer(dst io.Writer, src io.Reader, logger log.Logger) {
 	n, err := io.Copy(dst, src)
 	if err != nil {
 		if !strings.Contains(err.Error(), "context canceled") && !strings.Contains(err.Error(), "CANCEL") {


### PR DESCRIPTION
This PR fixes https://github.com/mmatczuk/go-http-tunnel/issues/44, `transfer` function is not closing connections anymore. Connections are closed externally after transferring data both ways.