### PR TITLE
Manage dead TCP connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,8 @@ import (
 var (
 	// DefaultTimeout specifies general purpose timeout.
 	DefaultTimeout = 10 * time.Second
+	// DefaultKeepAliveTimeout specifies the TCP keepalive timeout
+	DefaultKeepAliveTimeout = 60 * time.Second
 )
 
 // ClientConfig is configuration of the Client.
@@ -170,7 +172,7 @@ func (c *Client) dial() (net.Conn, error) {
 			conn, err = c.config.DialTLS(network, addr, tlsConfig)
 		} else {
 			conn, err = tls.DialWithDialer(
-				&net.Dialer{Timeout: DefaultTimeout},
+				&net.Dialer{Timeout: DefaultTimeout, KeepAlive: DefaultKeepAliveTimeout},
 				network, addr, tlsConfig,
 			)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -187,6 +187,14 @@ func TestIntegration(t *testing.T) {
 		}
 	}
 	wg.Wait()
+
+	c2 := makeTunnelClient(t, s.Addr(),
+		httpLocalAddr, http.Addr(),
+		tcpLocalAddr, tcp.Addr(),
+	)
+	time.Sleep(500 * time.Millisecond)
+	defer c2.Stop()
+
 }
 
 func testHTTP(t *testing.T, addr net.Addr, payload []byte, repeat uint) {


### PR DESCRIPTION
Fixes #49 for TCP based connections. 

Probably some issues remains for protocols not implementing the keepalive mechanism.