### PR TITLE
TCP keepalive

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/felixge/tcpkeepalive"
+  packages = ["."]
+  revision = "5bb0b2dea91e0de550022159b9571aafc72c08ba"
+
+[[projects]]
   name = "github.com/golang/mock"
   packages = ["gomock"]
   revision = "13f360950a79f5864a972c786a10a50e44b69541"
@@ -40,6 +46,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5f9ce2cfc77119828bda8371ed4da5c6a78ad469287571a166b9f412fecb73ae"
+  inputs-digest = "654fea302b8b5a71ce4f36f4097d0c0caa8150e46109cfbdd462adcd054a6768"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,3 +44,7 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/felixge/tcpkeepalive"

--- a/pool.go
+++ b/pool.go
@@ -5,10 +5,12 @@
 package tunnel
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"golang.org/x/net/http2"
 
@@ -37,6 +39,10 @@ func newConnPool(t *http2.Transport, l onDisconnectListener) *connPool {
 	}
 }
 
+func (p *connPool) URL(identifier id.ID) string {
+	return fmt.Sprint("https://", identifier)
+}
+
 func (p *connPool) GetClientConn(req *http.Request, addr string) (*http2.ClientConn, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -54,11 +60,7 @@ func (p *connPool) MarkDead(c *http2.ClientConn) {
 
 	for addr, cp := range p.conns {
 		if cp.clientConn == c {
-			cp.conn.Close()
-			delete(p.conns, addr)
-			if p.listener != nil {
-				p.listener(p.addrToIdentifier(addr))
-			}
+			p.close(cp, addr)
 			return
 		}
 	}
@@ -70,8 +72,12 @@ func (p *connPool) AddConn(conn net.Conn, identifier id.ID) error {
 
 	addr := p.addr(identifier)
 
-	if _, ok := p.conns[addr]; ok {
-		return errClientAlreadyConnected
+	if cp, ok := p.conns[addr]; ok {
+		if err := p.ping(cp); err != nil {
+			p.close(cp, addr)
+		} else {
+			return errClientAlreadyConnected
+		}
 	}
 
 	c, err := p.t.NewClientConn(conn)
@@ -93,24 +99,46 @@ func (p *connPool) DeleteConn(identifier id.ID) {
 	addr := p.addr(identifier)
 
 	if cp, ok := p.conns[addr]; ok {
-		cp.conn.Close()
-		delete(p.conns, addr)
-		if p.listener != nil {
-			p.listener(identifier)
-		}
+		p.close(cp, addr)
 	}
 }
 
-func (p *connPool) URL(identifier id.ID) string {
-	return fmt.Sprint("https://", identifier)
+func (p *connPool) Ping(identifier id.ID) (time.Duration, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	addr := p.addr(identifier)
+
+	if cp, ok := p.conns[addr]; ok {
+		start := time.Now()
+		err := p.ping(cp)
+		return time.Since(start), err
+	}
+
+	return 0, errClientNotConnected
+}
+
+func (p *connPool) ping(cp connPair) error {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultPingTimeout)
+	defer cancel()
+
+	return cp.clientConn.Ping(ctx)
+}
+
+func (p *connPool) close(cp connPair, addr string) {
+	cp.conn.Close()
+	delete(p.conns, addr)
+	if p.listener != nil {
+		p.listener(p.identifier(addr))
+	}
 }
 
 func (p *connPool) addr(identifier id.ID) string {
 	return fmt.Sprint(identifier.String(), ":443")
 }
 
-func (p *connPool) addrToIdentifier(addr string) id.ID {
-	identifier := id.ID{}
+func (p *connPool) identifier(addr string) id.ID {
+	var identifier id.ID
 	identifier.UnmarshalText([]byte(addr[:len(addr)-4]))
 	return identifier
 }

--- a/server.go
+++ b/server.go
@@ -150,7 +150,7 @@ func (s *Server) Start() {
 		if err := keepAlive(conn); err != nil {
 			s.logger.Log(
 				"level", 1,
-				"msg", "connection keepAlive failed",
+				"msg", "could not enable TCP keepalive for control connection",
 				"addr", addr,
 				"err", err,
 			)
@@ -406,6 +406,11 @@ rollback:
 func (s *Server) Unsubscribe(identifier id.ID) *RegistryItem {
 	s.connPool.DeleteConn(identifier)
 	return s.registry.Unsubscribe(identifier)
+}
+
+// Ping measures the RTT response time.
+func (s *Server) Ping(identifier id.ID) (time.Duration, error) {
+	return s.connPool.Ping(identifier)
 }
 
 func (s *Server) listen(l net.Listener, identifier id.ID) {

--- a/tunnel.go
+++ b/tunnel.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Michał Matczuk
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tunnel
+
+import "time"
+
+var (
+	// DefaultTimeout specifies a general purpose timeout.
+	DefaultTimeout = 10 * time.Second
+	// DefaultPingTimeout specifies a ping timeout.
+	DefaultPingTimeout = 500 * time.Millisecond
+
+	// DefaultKeepAliveIdleTime specifies how long connection can be idle
+	// before sending keepalive message.
+	DefaultKeepAliveIdleTime = 15 * time.Minute
+	// DefaultKeepAliveCount specifies maximal number of keepalive messages
+	// sent before marking connection as dead.
+	DefaultKeepAliveCount = 8
+	// DefaultKeepAliveInterval specifies how often retry sending keepalive
+	// messages when no response is received.
+	DefaultKeepAliveInterval = 5 * time.Second
+)

--- a/utils.go
+++ b/utils.go
@@ -6,11 +6,17 @@ package tunnel
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"strings"
 
+	"github.com/felixge/tcpkeepalive"
 	"github.com/mmatczuk/go-http-tunnel/log"
 )
+
+func keepAlive(conn net.Conn) error {
+	return tcpkeepalive.SetKeepAlive(conn, DefaultKeepAliveIdleTime, DefaultKeepAliveCount, DefaultKeepAliveInterval)
+}
 
 func transfer(dst io.Writer, src io.Reader, logger log.Logger) {
 	n, err := io.Copy(dst, src)


### PR DESCRIPTION
This is a modified version of https://github.com/mmatczuk/go-http-tunnel/pull/50.

TCP keepalive is enabled for client and server, a library is used to ensure consistent behavior on different platforms and to set custom keepalive idle timeout. Ping is exposed in Server API and returns RTT. On connect if ping does not return within 500ms the old client is disconnected.