### PR TITLE
keepalive: windows fix

### DIFF
--- a/keepalive.go
+++ b/keepalive.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 Michał Matczuk
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package tunnel
+
+import (
+	"net"
+	"time"
+
+	"github.com/felixge/tcpkeepalive"
+)
+
+var (
+	// DefaultKeepAliveIdleTime specifies how long connection can be idle
+	// before sending keepalive message.
+	DefaultKeepAliveIdleTime = 15 * time.Minute
+	// DefaultKeepAliveCount specifies maximal number of keepalive messages
+	// sent before marking connection as dead.
+	DefaultKeepAliveCount = 8
+	// DefaultKeepAliveInterval specifies how often retry sending keepalive
+	// messages when no response is received.
+	DefaultKeepAliveInterval = 5 * time.Second
+)
+
+func keepAlive(conn net.Conn) error {
+	return tcpkeepalive.SetKeepAlive(conn, DefaultKeepAliveIdleTime, DefaultKeepAliveCount, DefaultKeepAliveInterval)
+}

--- a/keepalive_windows.go
+++ b/keepalive_windows.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Michał Matczuk
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tunnel
+
+import (
+	"fmt"
+	"net"
+)
+
+func keepAlive(conn net.Conn) error {
+	c, ok := conn.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("Bad connection type: %T", c)
+	}
+
+	if err := c.SetKeepAlive(true); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tunnel.go
+++ b/tunnel.go
@@ -11,14 +11,4 @@ var (
 	DefaultTimeout = 10 * time.Second
 	// DefaultPingTimeout specifies a ping timeout.
 	DefaultPingTimeout = 500 * time.Millisecond
-
-	// DefaultKeepAliveIdleTime specifies how long connection can be idle
-	// before sending keepalive message.
-	DefaultKeepAliveIdleTime = 15 * time.Minute
-	// DefaultKeepAliveCount specifies maximal number of keepalive messages
-	// sent before marking connection as dead.
-	DefaultKeepAliveCount = 8
-	// DefaultKeepAliveInterval specifies how often retry sending keepalive
-	// messages when no response is received.
-	DefaultKeepAliveInterval = 5 * time.Second
 )

--- a/utils.go
+++ b/utils.go
@@ -10,13 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/felixge/tcpkeepalive"
 	"github.com/mmatczuk/go-http-tunnel/log"
 )
-
-func keepAlive(conn net.Conn) error {
-	return tcpkeepalive.SetKeepAlive(conn, DefaultKeepAliveIdleTime, DefaultKeepAliveCount, DefaultKeepAliveInterval)
-}
 
 func transfer(dst io.Writer, src io.Reader, logger log.Logger) {
 	n, err := io.Copy(dst, src)


### PR DESCRIPTION
This is a workaround over github.com/felixge/tcpkeepalive not supporting windows. I have no means to anything better then that for windows...