### PR TITLE
Allow setting the server hostname for TLS connection

### DIFF
--- a/cmd/tunnel/config.go
+++ b/cmd/tunnel/config.go
@@ -42,12 +42,13 @@ type Tunnel struct {
 
 // ClientConfig is a tunnel client configuration.
 type ClientConfig struct {
-	ServerAddr string             `yaml:"server_addr"`
-	TLSCrt     string             `yaml:"tls_crt"`
-	TLSKey     string             `yaml:"tls_key"`
-	RootCA     string             `yaml:"root_ca"`
-	Backoff    BackoffConfig      `yaml:"backoff"`
-	Tunnels    map[string]*Tunnel `yaml:"tunnels"`
+	ServerAddr     string             `yaml:"server_addr"`
+	ServerHostname string             `yaml:"server_hostname"`
+	TLSCrt         string             `yaml:"tls_crt"`
+	TLSKey         string             `yaml:"tls_key"`
+	RootCA         string             `yaml:"root_ca"`
+	Backoff        BackoffConfig      `yaml:"backoff"`
+	Tunnels        map[string]*Tunnel `yaml:"tunnels"`
 }
 
 func loadClientConfigFromFile(file string) (*ClientConfig, error) {

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -130,11 +130,15 @@ func tlsConfig(config *ClientConfig) (*tls.Config, error) {
 		}
 	}
 
-	host, _, err := net.SplitHostPort(config.ServerAddr)
-	if err != nil {
-		return nil, err
+	var host string
+	if config.ServerHostname != "" {
+		host = config.ServerHostname
+	} else {
+		host, _, err = net.SplitHostPort(config.ServerAddr)
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	return &tls.Config{
 		ServerName:         host,
 		Certificates:       []tls.Certificate{cert},


### PR DESCRIPTION
When using SAN certs, hostname verification is enforced.  If the server hostname in `server_addr` doesn't match one of the names in the cert, thenthe connection fails.  This PR allows you to specify an allowed hostname.  The use-case for this is that we have auto-generated certs per node in AWS,but are establishing the tunnel through an NLB.  The NLB hostname does not match what is in the cert, so the connection fails without this patch.