### PR TITLE
#119 Add log level constants

### DIFF
--- a/log/filterlogger.go
+++ b/log/filterlogger.go
@@ -4,6 +4,13 @@
 
 package log
 
+const (
+	LevelError = iota
+	LevelInfo
+	LevelDebug
+	LevelTrace
+)
+
 type filterLogger struct {
 	level  int
 	logger Logger

--- a/log/filterlogger_test.go
+++ b/log/filterlogger_test.go
@@ -29,3 +29,16 @@ func TestFilterLogger_Log(t *testing.T) {
 	f.Log("level", 3)
 	f.Log("level", 4)
 }
+
+func TestFilterLogger_Level(t *testing.T) {
+	for i, j := range map[int]int{
+		LevelError: 0,
+		LevelInfo:  1,
+		LevelDebug: 2,
+		LevelTrace: 3,
+	} {
+		if i != j {
+			t.Fatalf("Log levels not as expected %d != %d", i, j)
+		}
+	}
+}


### PR DESCRIPTION
No changes to current package interface.  
Adds 4 exported symbols to protect developers from magic numbers.

```go
logger := log.NewFilterLogger(log.NewStdLogger(), log.LevelInfo)
```

See #119 