### PR TITLE
Fix backoff inconsistency

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,13 +204,12 @@ func (c *Client) dial() (net.Conn, error) {
 	if b == nil {
 		return doDial()
 	}
-
+	b.Reset()
 	for {
 		conn, err := doDial()
 
 		// success
 		if err == nil {
-			b.Reset()
 			return conn, err
 		}
 


### PR DESCRIPTION
The reset is performed at the time the connection has been established. 
This can cause the problem described in #76.
I the server connection fails after max_time + x it tries to reconnect. 
If that fails once it immediately stops trying with the message "backoff limit exceeded"